### PR TITLE
Added flag to avoid JSON.stringify

### DIFF
--- a/lib/rest-emulator.js
+++ b/lib/rest-emulator.js
@@ -73,7 +73,13 @@ function restEmulator(listMockConfig, options) {
                 res.set(preset.headers);
             }
             res.statusCode = preset.code;
-            res.write(JSON.stringify(preset.data));
+            var data;
+            if (preset.raw) {
+                data = preset.data;
+            } else {
+                data = JSON.stringify(preset.data);
+            }
+            res.write(data);
             res.end();
             return true;
         }


### PR DESCRIPTION
JSON.stringify adds quotationmarks if the passed data is not in json format. I've added a flag to avoid the conversion to json to prevent this behaviour.
